### PR TITLE
Allow better reading of text over image

### DIFF
--- a/static/css/page.css
+++ b/static/css/page.css
@@ -29,6 +29,7 @@ body, html {
 .homeDiv {
     font-family: "Gravity-Book";
     color: white;
+    backdrop-filter: blur(1px);
 }
 
 .homeMainTitle {


### PR DESCRIPTION
In order to achieve better reading of the text over sharp image, we could blur the background of the text, or the whole image.
You can check more about it [here](https://css-tricks.com/design-considerations-text-images/#blurring)

![blur](https://user-images.githubusercontent.com/21321095/126604516-6d66edab-317f-452b-88e1-91e6445faf57.gif)